### PR TITLE
Fixes error when using annotations and $tableConfig truncate's key is not defined

### DIFF
--- a/src/Config/TargetFactory.php
+++ b/src/Config/TargetFactory.php
@@ -95,7 +95,7 @@ class TargetFactory
                 }
             }
 
-            $targetTables[] = new TargetTable($tableName, $primaryKey, $targetFields, $tableConfig['truncate']);
+            $targetTables[] = new TargetTable($tableName, $primaryKey, $targetFields, $tableConfig['truncate'] ?? false);
         }
 
         return $targetTables;


### PR DESCRIPTION
I got an error when using the bundle with annotations.
It was because at no point the `truncate` key was defined.

This fix makes sure it defaults to false and produces no error in cases the key is not defined.